### PR TITLE
Add Rust CLI crate

### DIFF
--- a/svgnest_cli/Cargo.toml
+++ b/svgnest_cli/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "svgnest_cli"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/svgnest_cli/src/main.rs
+++ b/svgnest_cli/src/main.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+use clap::Parser;
+
+/// Simple command line interface for SVGnest
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// Path to a configuration file in JSON format
+    #[arg(short, long)]
+    config: Option<PathBuf>,
+}
+
+fn main() {
+    let args = Args::parse();
+    if let Some(cfg) = args.config {
+        println!("Using config: {}", cfg.display());
+    } else {
+        println!("No configuration provided");
+    }
+}


### PR DESCRIPTION
## Summary
- initialize a new Cargo binary crate `svgnest_cli`
- set up `clap`, `serde`, and `serde_json` dependencies
- add an argument parser in `main.rs`

## Testing
- `cargo build` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685fd5e9cb30832db6f50faf1d4742a6