### PR TITLE
Add CLI options for svgnest_cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+svgnest_cli/target/
+svgnest_cli/Cargo.lock

--- a/svgnest_cli/src/main.rs
+++ b/svgnest_cli/src/main.rs
@@ -1,20 +1,78 @@
-use std::path::PathBuf;
 use clap::Parser;
+use std::path::PathBuf;
 
-/// Simple command line interface for SVGnest
+/// Command line arguments for SVGnest
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
-struct Args {
-    /// Path to a configuration file in JSON format
-    #[arg(short, long)]
-    config: Option<PathBuf>,
+pub struct CliArgs {
+    /// SVG input files to be nested
+    #[arg(long, value_name = "FILES", required = true)]
+    pub inputs: Vec<PathBuf>,
+
+    /// Maximum error allowed when approximating curves
+    #[arg(long, default_value_t = 0.3)]
+    pub curve_tolerance: f64,
+
+    /// Minimum space between parts
+    #[arg(long, default_value_t = 0.0)]
+    pub spacing: f64,
+
+    /// Number of rotations to test for each part
+    #[arg(long, default_value_t = 4)]
+    pub rotations: usize,
+
+    /// Population size for the genetic algorithm
+    #[arg(long, default_value_t = 10, value_name = "SIZE")]
+    pub population_size: usize,
+
+    /// Mutation rate of the genetic algorithm (1-50)
+    #[arg(long, default_value_t = 10, value_name = "RATE")]
+    pub mutation_rate: usize,
+
+    /// Place parts inside the holes of other parts
+    #[arg(long, default_value_t = false)]
+    pub use_holes: bool,
+
+    /// Explore concave areas for more robust placement
+    #[arg(long, default_value_t = false)]
+    pub explore_concave: bool,
+}
+
+/// Parsed configuration returned by the CLI
+#[derive(Debug)]
+pub struct Config {
+    pub inputs: Vec<PathBuf>,
+    pub curve_tolerance: f64,
+    pub spacing: f64,
+    pub rotations: usize,
+    pub population_size: usize,
+    pub mutation_rate: usize,
+    pub use_holes: bool,
+    pub explore_concave: bool,
+}
+
+impl From<CliArgs> for Config {
+    fn from(args: CliArgs) -> Self {
+        Self {
+            inputs: args.inputs,
+            curve_tolerance: args.curve_tolerance,
+            spacing: args.spacing,
+            rotations: args.rotations,
+            population_size: args.population_size,
+            mutation_rate: args.mutation_rate,
+            use_holes: args.use_holes,
+            explore_concave: args.explore_concave,
+        }
+    }
+}
+
+/// Parse command line arguments into a configuration struct
+pub fn parse_config() -> Config {
+    let args = CliArgs::parse();
+    args.into()
 }
 
 fn main() {
-    let args = Args::parse();
-    if let Some(cfg) = args.config {
-        println!("Using config: {}", cfg.display());
-    } else {
-        println!("No configuration provided");
-    }
+    let cfg = parse_config();
+    println!("{:?}", cfg);
 }


### PR DESCRIPTION
## Summary
- implement full set of CLI options in `main.rs`
- expose `parse_config` helper returning struct for later use
- ignore build artifacts

## Testing
- `cargo test --manifest-path svgnest_cli/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_685fd6afe954832dac640fdd6b1dbdd1