### PR TITLE
Add Rust CLI tests and geometry test coverage

### DIFF
--- a/svgnest_cli/Cargo.toml
+++ b/svgnest_cli/Cargo.toml
@@ -14,3 +14,8 @@ geo = "0.30.0"
 geo-clipper = "0.9.0"
 rand = "0.8"
 rayon = "1"
+
+[dev-dependencies]
+assert_cmd = "2"
+assert_fs = "1"
+predicates = "3"

--- a/svgnest_cli/src/geometry.rs
+++ b/svgnest_cli/src/geometry.rs
@@ -82,4 +82,35 @@ mod tests {
         assert_eq!(bounds.width, 1.0);
         assert_eq!(bounds.height, 1.0);
     }
+
+    #[test]
+    fn area_of_triangle_ccw() {
+        let pts = vec![
+            Point { x: 0.0, y: 0.0 },
+            Point { x: 1.0, y: 0.0 },
+            Point { x: 0.0, y: 1.0 },
+        ];
+        assert!((polygon_area(&pts) + 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rotate_preserves_bounds() {
+        let pts = vec![
+            Point { x: 0.0, y: 0.0 },
+            Point { x: 1.0, y: 0.0 },
+            Point { x: 1.0, y: 1.0 },
+            Point { x: 0.0, y: 1.0 },
+        ];
+        let rotated = rotate_polygon(&pts, 90.0);
+        let b = get_polygon_bounds(&rotated).unwrap();
+        assert!((b.width - 1.0).abs() < 1e-6);
+        assert!((b.height - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn degenerate_polygon() {
+        let pts = vec![Point { x: 0.0, y: 0.0 }, Point { x: 1.0, y: 0.0 }];
+        assert_eq!(polygon_area(&pts), 0.0);
+        assert!(get_polygon_bounds(&pts).is_none());
+    }
 }

--- a/svgnest_cli/tests/cli.rs
+++ b/svgnest_cli/tests/cli.rs
@@ -1,0 +1,27 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+
+#[test]
+fn cli_processes_sample_svgs() -> Result<(), Box<dyn std::error::Error>> {
+    let bin = "tests/fixtures/bin.svg";
+    let part = "tests/fixtures/part.svg";
+    Command::cargo_bin("svgnest_cli")?
+        .args([
+            "--inputs", bin,
+            "--inputs", part,
+            "--population-size", "1",
+            "--mutation-rate", "0",
+            "--rotations", "0",
+            "--spacing", "0",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Nested result written"));
+
+    let output = fs::read_to_string("nested.svg")?;
+    let expected = fs::read_to_string("tests/fixtures/expected.svg")?;
+    assert_eq!(output.trim(), expected.trim());
+    fs::remove_file("nested.svg")?;
+    Ok(())
+}

--- a/svgnest_cli/tests/fixtures/bin.svg
+++ b/svgnest_cli/tests/fixtures/bin.svg
@@ -1,0 +1,1 @@
+<svg><rect x="0" y="0" width="10" height="10"/></svg>

--- a/svgnest_cli/tests/fixtures/expected.svg
+++ b/svgnest_cli/tests/fixtures/expected.svg
@@ -1,0 +1,2 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><polygon points="0,0 5,0 5,5 0,5" fill="none" stroke="black"/>
+<rect x="0" y="0" width="10" height="10" fill="none" stroke="blue"/></svg>

--- a/svgnest_cli/tests/fixtures/part.svg
+++ b/svgnest_cli/tests/fixtures/part.svg
@@ -1,0 +1,1 @@
+<svg><rect x="0" y="0" width="5" height="5"/></svg>


### PR DESCRIPTION
## Summary
- expand geometry unit tests for area, bounds and degenerate polygons
- add integration test for CLI using small SVG fixtures
- include sample SVGs and expected nested output

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685fddf6c624832d920cac8103528653