### PR TITLE
Add tolerance-based SVG path approximation

### DIFF
--- a/svgnest_cli/Cargo.toml
+++ b/svgnest_cli/Cargo.toml
@@ -9,6 +9,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 roxmltree = "0.20"
 svg-path-parser = "0.1"
+lyon_path = "0.17"
+lyon_svg = "0.17"
 anyhow = "1"
 geo = "0.30.0"
 geo-clipper = "0.9.0"

--- a/svgnest_cli/src/main.rs
+++ b/svgnest_cli/src/main.rs
@@ -16,8 +16,8 @@ pub struct CliArgs {
     pub inputs: Vec<PathBuf>,
 
     /// Maximum error allowed when approximating curves
-    #[arg(long, default_value_t = 0.3)]
-    pub curve_tolerance: f64,
+    #[arg(long = "approx-tolerance", default_value_t = 0.3)]
+    pub approx_tolerance: f64,
 
     /// Minimum space between parts
     #[arg(long, default_value_t = 0.0)]
@@ -52,7 +52,7 @@ pub struct CliArgs {
 #[derive(Debug)]
 pub struct Config {
     pub inputs: Vec<PathBuf>,
-    pub curve_tolerance: f64,
+    pub approx_tolerance: f64,
     pub spacing: f64,
     pub rotations: usize,
     pub population_size: usize,
@@ -66,7 +66,7 @@ impl From<CliArgs> for Config {
     fn from(args: CliArgs) -> Self {
         Self {
             inputs: args.inputs,
-            curve_tolerance: args.curve_tolerance,
+            approx_tolerance: args.approx_tolerance,
             spacing: args.spacing,
             rotations: args.rotations,
             population_size: args.population_size,
@@ -93,7 +93,7 @@ fn main() {
         let res = if ext.eq_ignore_ascii_case("dxf") {
             dxf_parser::polygons_from_dxf(path)
         } else {
-            svg_parser::polygons_from_file(path, cfg.merge_lines)
+            svg_parser::polygons_from_file(path, cfg.merge_lines, cfg.approx_tolerance)
         };
         match res {
             Ok(mut p) => all_polys.append(&mut p),

--- a/svgnest_cli/tests/cli.rs
+++ b/svgnest_cli/tests/cli.rs
@@ -1,17 +1,21 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use assert_fs::TempDir;
 use std::fs;
+use std::path::PathBuf;
 
 #[test]
 fn cli_processes_sample_svgs() -> Result<(), Box<dyn std::error::Error>> {
-    let bin = "tests/fixtures/bin.svg";
-    let part = "tests/fixtures/part.svg";
+    let bin = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/bin.svg");
+    let part = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/part.svg");
+    let tmp = TempDir::new()?;
     Command::cargo_bin("svgnest_cli")?
+        .current_dir(&tmp)
         .args([
             "--inputs",
-            bin,
+            bin.to_str().unwrap(),
             "--inputs",
-            part,
+            part.to_str().unwrap(),
             "--population-size",
             "1",
             "--mutation-rate",
@@ -25,23 +29,25 @@ fn cli_processes_sample_svgs() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains("Nested result written"));
 
-    let output = fs::read_to_string("nested.svg")?;
+    let output = fs::read_to_string(tmp.path().join("nested.svg"))?;
     let expected = fs::read_to_string("tests/fixtures/expected.svg")?;
     assert_eq!(output.trim(), expected.trim());
-    fs::remove_file("nested.svg")?;
+    tmp.close()?;
     Ok(())
 }
 
 #[test]
 fn cli_processes_dxf() -> Result<(), Box<dyn std::error::Error>> {
-    let bin = "tests/fixtures/bin.dxf";
-    let part = "tests/fixtures/part.dxf";
+    let bin = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/bin.dxf");
+    let part = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/part.dxf");
+    let tmp = TempDir::new()?;
     Command::cargo_bin("svgnest_cli")?
+        .current_dir(&tmp)
         .args([
             "--inputs",
-            bin,
+            bin.to_str().unwrap(),
             "--inputs",
-            part,
+            part.to_str().unwrap(),
             "--population-size",
             "1",
             "--mutation-rate",
@@ -55,9 +61,9 @@ fn cli_processes_dxf() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains("Nested result written"));
 
-    let output = fs::read_to_string("nested.svg")?;
+    let output = fs::read_to_string(tmp.path().join("nested.svg"))?;
     let expected = fs::read_to_string("tests/fixtures/expected.svg")?;
     assert_eq!(output.trim(), expected.trim());
-    fs::remove_file("nested.svg")?;
+    tmp.close()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- parse SVG paths using lyon with tolerance
- expose `--approx-tolerance` CLI option
- update CLI tests to use temporary directories
- add tests covering path approximation accuracy

## Testing
- `cargo test --manifest-path svgnest_cli/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_685fe515e030832db17ac59495510753