### PR TITLE
Improve SVG transform parsing

### DIFF
--- a/svgnest_cli/Cargo.toml
+++ b/svgnest_cli/Cargo.toml
@@ -17,6 +17,7 @@ geo-clipper = "0.9.0"
 rand = "0.8"
 rayon = "1"
 dxf = { version = "0.6", optional = true }
+svgtypes = "0.5"
 
 [features]
 default = ["dxf"]


### PR DESCRIPTION
## Summary
- parse `transform` attributes using `svgtypes`
- add parsing tests for translate, scale and rotate with commas/spaces
- depend on `svgtypes`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860033e498c832d82f1dbe5ea4e6f93