### PR TITLE
Add Minkowski and offset helpers

### DIFF
--- a/svgnest_cli/src/main.rs
+++ b/svgnest_cli/src/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 mod dxf_parser;
 mod ga;
 mod geometry;
+mod nfp;
 mod line_merge;
 mod part;
 mod svg_parser;

--- a/svgnest_cli/src/nfp.rs
+++ b/svgnest_cli/src/nfp.rs
@@ -1,0 +1,33 @@
+use crate::geometry::{minkowski_difference, offset_polygon};
+use crate::svg_parser::Point;
+
+/// Outer no-fit polygon of two shapes.
+/// This is a very approximate implementation intended for testing.
+pub fn no_fit_polygon(a: &[Point], b: &[Point], spacing: f64) -> Option<Vec<Point>> {
+    let mut nfp = minkowski_difference(a, b);
+    if nfp.is_empty() {
+        return None;
+    }
+    if spacing != 0.0 {
+        nfp = nfp
+            .into_iter()
+            .flat_map(|poly| offset_polygon(&poly, spacing))
+            .collect();
+    }
+    nfp.into_iter().next()
+}
+
+/// Inner fit polygon of a part inside a bin.
+pub fn inner_fit_polygon(bin: &[Point], part: &[Point], spacing: f64) -> Option<Vec<Point>> {
+    let mut nfp = minkowski_difference(bin, part);
+    if nfp.is_empty() {
+        return None;
+    }
+    if spacing != 0.0 {
+        nfp = nfp
+            .into_iter()
+            .flat_map(|poly| offset_polygon(&poly, -spacing))
+            .collect();
+    }
+    nfp.into_iter().next()
+}


### PR DESCRIPTION
## Summary
- add `offset_polygon` and `minkowski_difference` helpers
- include a new `nfp` module with rough NFP helpers
- expose the new module in the CLI

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860c8641978832dbddac0655eb8562c