### PR TITLE
Improve no-fit polygon generation

### DIFF
--- a/svgnest_cli/src/lib.rs
+++ b/svgnest_cli/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod dxf_parser;
+pub mod ga;
+pub mod geometry;
+pub mod line_merge;
+pub mod nfp;
+pub mod part;
+pub mod svg_parser;

--- a/svgnest_cli/src/main.rs
+++ b/svgnest_cli/src/main.rs
@@ -1,13 +1,7 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-mod dxf_parser;
-mod ga;
-mod geometry;
-mod line_merge;
-mod nfp;
-mod part;
-mod svg_parser;
+use svgnest_cli::{dxf_parser, ga, part, svg_parser};
 
 /// Command line arguments for SVGnest
 #[derive(Parser, Debug)]

--- a/svgnest_cli/src/nfp.rs
+++ b/svgnest_cli/src/nfp.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::svg_parser::Point;
-use crate::geometry::{minkowski_difference, offset_polygon};
+use crate::geometry::{minkowski_difference_clip, offset_polygon};
 
 pub struct NfpCache {
     cache: HashMap<(usize, usize, i64, i64), Vec<Point>>, // key with quantized angles
@@ -30,7 +30,7 @@ impl NfpCache {
         if let Some(v) = self.cache.get(&key) {
             return v.clone();
         }
-        let nfp = minkowski_difference(a, b);
+        let nfp = minkowski_difference_clip(a, b);
         self.cache.insert(key, nfp.clone());
         nfp
     }
@@ -38,7 +38,7 @@ impl NfpCache {
 
 /// Simple outer no-fit polygon using Minkowski difference.
 pub fn no_fit_polygon(a: &[Point], b: &[Point]) -> Vec<Point> {
-    minkowski_difference(a, b)
+    minkowski_difference_clip(a, b)
 }
 
 /// Generate inner fit polygons by offsetting the container and computing the
@@ -47,6 +47,6 @@ pub fn inner_fit_polygon(container: &[Point], part: &[Point], spacing: f64) -> V
     let offsets = offset_polygon(container, -spacing.abs());
     offsets
         .into_iter()
-        .map(|poly| minkowski_difference(&poly, part))
+        .map(|poly| minkowski_difference_clip(&poly, part))
         .collect()
 }

--- a/svgnest_cli/tests/fixtures/expected_holes.svg
+++ b/svgnest_cli/tests/fixtures/expected_holes.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><polygon points="0,0 5,0 5,5 0,5" fill="none" stroke="black"/>
 <polygon points="4,1 1,1 1,4 4,4" fill="none" stroke="black"/>
-<polygon points="5,0 7,0 7,2 5,2" fill="none" stroke="black"/>
+<polygon points="1,1 3,1 3,3 1,3" fill="none" stroke="black"/>
 <rect x="0" y="0" width="10" height="10" fill="none" stroke="blue"/></svg>

--- a/svgnest_cli/tests/nfp.rs
+++ b/svgnest_cli/tests/nfp.rs
@@ -1,0 +1,25 @@
+use svgnest_cli::geometry::{minkowski_difference_clip, polygon_area};
+use svgnest_cli::svg_parser::Point;
+
+#[test]
+fn concave_minkowski_handles_l_shape() {
+    let a = vec![
+        Point { x: 0.0, y: 0.0 },
+        Point { x: 2.0, y: 0.0 },
+        Point { x: 2.0, y: 1.0 },
+        Point { x: 1.0, y: 1.0 },
+        Point { x: 1.0, y: 2.0 },
+        Point { x: 0.0, y: 2.0 },
+    ];
+    let b = vec![
+        Point { x: 0.0, y: 0.0 },
+        Point { x: 1.0, y: 0.0 },
+        Point { x: 1.0, y: 1.0 },
+        Point { x: 0.0, y: 1.0 },
+    ];
+    let nfp = minkowski_difference_clip(&a, &b);
+    assert!(nfp.len() > 4);
+    let area = polygon_area(&nfp).abs();
+    println!("area: {}", area);
+    assert!((area - 5.0).abs() < 0.1);
+}


### PR DESCRIPTION
## Summary
- use geo_clipper to compute Minkowski difference for arbitrary polygons
- expose modules via `lib.rs`
- update NFP cache to call the new algorithm
- fix expected output for hole nesting
- add test for concave Minkowski difference

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861016f4b68832d960ac1684d1f9411