### PR TITLE
Reuse global NFP cache

### DIFF
--- a/svgnest_cli/src/main.rs
+++ b/svgnest_cli/src/main.rs
@@ -149,13 +149,13 @@ fn main() {
             .partial_cmp(&b.fitness)
             .unwrap_or(std::cmp::Ordering::Equal)
     }) {
-        Some(v) => v,
+        Some(v) => v.clone(),
         None => {
             eprintln!("No population available to evaluate");
             return;
         }
     };
-    let svg = ga.create_svg(best);
+    let svg = ga.create_svg(&best);
     if let Err(e) = std::fs::write("nested.svg", svg) {
         eprintln!("Failed to write SVG: {}", e);
         return;


### PR DESCRIPTION
## Summary
- cache NFP calculations in `GeneticAlgorithm`
- create NFP cache once in `new`
- reuse cache when evaluating population and while laying out parts

## Testing
- `cargo test --manifest-path svgnest_cli/Cargo.toml -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_686147d15444832dbb4a891b73134a0b